### PR TITLE
fix: generation for mqtt and amqp

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#Java Spring generator
+# Java Spring generator
 _Use your AsyncAPI definition to generate java code to subscribe and publish messages_
 
 
@@ -120,7 +120,7 @@ See the list of features that are still missing in the component:
 - [ ] support of Kafka is done based on clear "spring-kafka" library without integration like for mqtt or amqp
 - [ ] generated code for protocols mqtt and amqp could be out of date. Please have a look to [application.yaml](template/src/main/resources/application.yml) and [AmqpConfig.java](partials/AmqpConfig.java), [MqttConfig.java](partials/MqttConfig.java) 
 - [ ] tests are not provided
-- [ ] add annotation to the [model generation](template/src/main/java/com/asyncapi/model). Consider "@Valid", "@JsonProperty", "@Size", "@NotNull" e.t.c.
+- [x] add annotation to the [model generation](template/src/main/java/com/asyncapi/model). Consider "@Valid", "@JsonProperty", "@Size", "@NotNull" e.t.c.
 - [ ] [`parameters`](https://github.com/asyncapi/asyncapi/blob/master/versions/2.0.0/asyncapi.md#parametersObject) for topics are not supported
 - [ ] [`server variables`](https://github.com/asyncapi/asyncapi/blob/master/versions/2.0.0/asyncapi.md#serverVariableObject) are not entirely supported 
 - [ ] [`security schemas`](https://github.com/asyncapi/asyncapi/blob/master/versions/2.0.0/asyncapi.md#securitySchemeObject) are not supported

--- a/filters/all.js
+++ b/filters/all.js
@@ -34,6 +34,8 @@ module.exports = ({ Nunjucks }) => {
         return 'double';
       case 'binary':
         return 'byte[]';
+      default:
+        return 'Object';
     }
   });
 
@@ -43,6 +45,35 @@ module.exports = ({ Nunjucks }) => {
 
   Nunjucks.addFilter('print', (str) => {
     console.error(str);
+  });
+
+  Nunjucks.addFilter('examplesToString', (ex) => {
+    let retStr = "";
+    ex.forEach(example => {
+      if (retStr !== "") {retStr += ", "}
+      if (typeof example == "object") {
+        try {
+          retStr += JSON.stringify(example);
+        } catch (ignore) {
+          retStr += example;
+        }
+      } else {
+        retStr += example;
+      }
+    });
+    return retStr;
+  });
+
+  Nunjucks.addFilter('splitByLines', (str) => {
+    if (str) {
+      return str.split(/\r?\n|\r/);
+    } else {
+      return "";
+    }
+  });
+
+  Nunjucks.addFilter('isRequired', (name, list) => {
+    return list && list.includes(name);
   });
 
   Nunjucks.addFilter('schemeExists', (collection, scheme) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@asyncapi/java-spring-template",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asyncapi/java-spring-template",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Java Spring template for AsyncAPI generator.",
   "keywords": [
     "asyncapi",

--- a/partials/MqttConfig.java
+++ b/partials/MqttConfig.java
@@ -61,7 +61,7 @@ public class Config {
 
     @Autowired
     MessageHandlerService messageHandlerService;
-    {% for channelName, channel in asyncapi.channels().publish() %}
+    {% for channelName, channel in asyncapi.channels() %}{% if channel.hasPublish() %}
 
     @Bean
     public IntegrationFlow {{channelName | camelCase}}Flow() {
@@ -78,10 +78,10 @@ public class Config {
         adapter.setConverter(new DefaultPahoMessageConverter());
         return adapter;
     }
-    {% endfor %}
+    {% endif %}{% endfor %}
 
     // publisher
-    {% for channelName, channel in asyncapi.channels().subscribe() %}
+    {% for channelName, channel in asyncapi.channels() %}{% if channel.hasSubscribe() %}
 
     @Bean
     public MessageChannel {{channelName | camelCase}}OutboundChannel() {
@@ -96,7 +96,7 @@ public class Config {
         pahoMessageHandler.setDefaultTopic({{channelName}}Topic);
         return pahoMessageHandler;
     }
-    {% endfor %}
+    {% endif %}{% endfor %}
 
 }
 {% endmacro %}

--- a/template/build.gradle
+++ b/template/build.gradle
@@ -21,8 +21,9 @@ dependencies {
 	{% endif -%}
 	{%- if asyncapi | isProtocol('kafka') %}
 	implementation('org.springframework.kafka:spring-kafka')
-	implementation('com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider')
 	{% endif -%}
+    implementation('com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider')
+    implementation('javax.validation:validation-api')
 	implementation('org.springframework.boot:spring-boot-starter-integration')
 	testImplementation('org.springframework.boot:spring-boot-starter-test')
 }

--- a/template/src/main/java/com/asyncapi/model/$$message$$.java
+++ b/template/src/main/java/com/asyncapi/model/$$message$$.java
@@ -1,5 +1,9 @@
 package com.asyncapi.model;
 
+{% if message.description() or message.examples()%}/**{% for line in message.description() | splitByLines %}
+ * {{ line | safe}}{% endfor %}{% if message.examples() %}
+ * Examples: {{message.examples() | examplesToString | safe}}{% endif %}
+ */{% endif %}
 public class {{messageName | camelCase | upperFirst}} {
     {% set payloadName = message.payload().uid() | camelCase | upperFirst %}
     private {{payloadName}} payload;

--- a/template/src/main/java/com/asyncapi/model/$$schema$$.java
+++ b/template/src/main/java/com/asyncapi/model/$$schema$$.java
@@ -1,44 +1,62 @@
 package com.asyncapi.model;
 
+import javax.validation.constraints.*;
+import javax.validation.Valid;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+{% if schema.description() or schema.examples() %}/**{% for line in schema.description() | splitByLines %}
+ * {{ line | safe}}{% endfor %}{% if schema.examples() %}
+ * Examples: {{schema.examples() | examplesToString | safe}}{% endif %}
+ */{% endif %}
 public class {{schemaName | camelCase | upperFirst}} {
     {% for propName, prop in schema.properties() %}
         {%- if prop.type() === 'object' %}
-    private {{prop.uid() | camelCase | upperFirst}} {{propName | camelCase}};
-        {% elif prop.type() === 'array' %}
+    private @Valid {{prop.uid() | camelCase | upperFirst}} {{propName | camelCase}};
+        {%- elif prop.type() === 'array' %}
             {%- if prop.items().format() %}
-    private {{prop.items().format() | toJavaType}}[] {{propName | camelCase}}Array;
+    private @Valid {{prop.items().format() | toJavaType}}[] {{propName | camelCase}}Array;
             {%- else %}
-    private {{prop.items().type() | toJavaType}}[] {{propName | camelCase}}Array;
-            {% endif %}
-        {% else %}
+    private @Valid {{prop.items().type() | toJavaType}}[] {{propName | camelCase}}Array;
+            {%- endif %}
+        {%- else %}
             {%- if prop.format() %}
-    private {{prop.format() | toJavaType}} {{propName | camelCase}};
+    private @Valid {{prop.format() | toJavaType}} {{propName | camelCase}};
             {%- else %}
-    private {{prop.type() | toJavaType}} {{propName | camelCase}};
+    private @Valid {{prop.type() | toJavaType}} {{propName | camelCase}};
             {%- endif %}
         {%- endif %}
-
     {% endfor %}
 
     {% for propName, prop in schema.properties() %}
-        {% set varName = propName | camelCase %}
-        {% set className = propName | camelCase | upperFirst %}
-        {% if prop.type() === 'object' %}
-            {% set propType = prop.uid() | camelCase | upperFirst %}
-        {% elif prop.type() === 'array' %}
-            {% set varName = propName | camelCase + 'Array' %}
-            {% if prop.items().format() %}
-                {% set propType = prop.items().format() | toJavaType + '[]' %}
-            {% else %}
-                {% set propType = prop.items().type() | toJavaType + '[]' %}
-            {% endif %}
-        {% else %}
-            {% if prop.format() %}
-                {% set propType = prop.format() | toJavaType %}
-            {% else %}
-                {% set propType = prop.type() | toJavaType %}
-            {% endif %}
+        {%- set varName = propName | camelCase %}
+        {%- set className = propName | camelCase | upperFirst %}
+        {%- if prop.type() === 'object' %}
+            {%- set propType = prop.uid() | camelCase | upperFirst %}
+        {%- elif prop.type() === 'array' %}
+            {%- set varName = propName | camelCase + 'Array' %}
+            {%- if prop.items().format() %}
+                {%- set propType = prop.items().format() | toJavaType + '[]' %}
+            {%- else %}
+                {%- set propType = prop.items().type() | toJavaType + '[]' %}
+            {%- endif %}
+        {%- else %}
+            {%- if prop.format() %}
+                {%- set propType = prop.format() | toJavaType %}
+            {%- else %}
+                {%- set propType = prop.type() | toJavaType %}
+            {%- endif %}
         {%- endif %}
+
+    {% if prop.description() or prop.examples()%}/**{% for line in prop.description() | splitByLines %}
+     * {{ line | safe}}{% endfor %}{% if prop.examples() %}
+     * Examples: {{prop.examples() | examplesToString | safe}}{% endif %}
+     */{% endif %}
+    @JsonProperty("{{propName}}")
+    {%- if propName | isRequired(schema.required()) %}@NotNull{% endif %}
+    {%- if prop.minLength() or prop.maxLength() or prop.maxItems() or prop.minItems() %}@Size({% if prop.minLength() or prop.minItems() %}min = {{prop.minLength()}}{{prop.minItems()}}{% endif %}{% if prop.maxLength() or prop.maxItems() %}{% if prop.minLength() or prop.minItems() %},{% endif %}max = {{prop.maxLength()}}{{prop.maxItems()}}{% endif %}){% endif %}
+    {%- if prop.pattern() %}@Pattern(regexp="{{prop.pattern()}}"){% endif %}
+    {%- if prop.minimum() %}@Min({{prop.minimum()}}){% endif %}{% if prop.exclusiveMinimum() %}@Min({{prop.exclusiveMinimum() + 1}}){% endif %}
+    {%- if prop.maximum() %}@Max({{prop.maximum()}}){% endif %}{% if prop.exclusiveMaximum() %}@Max({{prop.exclusiveMaximum() + 1}}){% endif %}
     public {{propType}} get{{className}}() {
         return {{varName}};
     }

--- a/template/src/main/resources/application.yml
+++ b/template/src/main/resources/application.yml
@@ -8,40 +8,38 @@
         {%- set hasSubscribe = true -%}
     {%- endif -%}
 {%- endfor -%}
-{%- if asyncapi | isProtocol('amqp') %}
+{%- for serverName, server in asyncapi.servers() %}{% if server.protocol() == 'amqp' %}
 amqp:
   broker:
-    host: localhost
-    port: 5672
-    username: guest
-    password: guest
+    host: {{server.url()}}
+    port: {{server.variable('port').defaultValue()}}
+    username:
+    password:
   exchange:
   {% for channelName, channel in asyncapi.channels() %}
     {% if channel.hasSubscribe() and channel.subscribe().bindings('amqp') %}
-    {{channel.subscribe().bindings('amqp').exchange().name()}}: {{channelName}}
+    {{channelName}}: {{channel.subscribe().binding('amqp').exchange.name}}
     {% endif %}
   {% endfor %}
   queue:
   {% for channelName, channel in asyncapi.channels() %}
-    {% if channel.hasPublish() and channel.publish().bindings('amqp') %}
-    {{channel.publish().bindings('amqp').queue().name()}}: {{channelName}}
+    {% if channel.hasPublish() and channel.publish().binding('amqp') %}
+    {{channelName}}: {{channel.publish().binding('amqp').queue.name}}
     {% endif %}
   {% endfor %}
 {% endif %}
-{%- if asyncapi | isProtocol('mqtt') %}
-  {% for serverName, server in asyncapi.servers() %}
+{% if server.protocol() == 'mqtt' %}
 mqtt:
   broker:
     host: tcp://{{server.url()}}
-    port: {{server.variables(port).defaultValue()}}
+    port: {{server.variable('port').defaultValue()}}
     username:
     password:
   topic:
     {% for channelName, channel in asyncapi.channels() %}
     {{channelName}}Topic: {{channelName}}
     {% endfor %}
-  {% endfor %}
-{% endif %}
+{% endif %}{% endfor %}
 {%- if asyncapi | isProtocol('kafka') %}
 kafka:
   bootstrap-servers: {% for serverName, server in asyncapi.servers() %}{{server.url()}}{% if not loop.last %},{% endif %}{% endfor %}

--- a/template/src/main/resources/application.yml
+++ b/template/src/main/resources/application.yml
@@ -17,7 +17,7 @@ amqp:
     password:
   exchange:
   {% for channelName, channel in asyncapi.channels() %}
-    {% if channel.hasSubscribe() and channel.subscribe().bindings('amqp') %}
+    {% if channel.hasSubscribe() and channel.subscribe().binding('amqp') %}
     {{channelName}}: {{channel.subscribe().binding('amqp').exchange.name}}
     {% endif %}
   {% endfor %}

--- a/template/src/main/resources/application.yml
+++ b/template/src/main/resources/application.yml
@@ -11,8 +11,8 @@
 {%- for serverName, server in asyncapi.servers() %}{% if server.protocol() == 'amqp' %}
 amqp:
   broker:
-    host: {{server.url()}}
-    port: {{server.variable('port').defaultValue()}}
+    host: {{server.url() | replace(':{port}', '') }}
+    port: {% if server.variable('port') %}{{server.variable('port').defaultValue()}}{% endif %}
     username:
     password:
   exchange:
@@ -31,8 +31,8 @@ amqp:
 {% if server.protocol() == 'mqtt' %}
 mqtt:
   broker:
-    host: tcp://{{server.url()}}
-    port: {{server.variable('port').defaultValue()}}
+    host: tcp://{{server.url() | replace(':{port}', '')}}
+    port: {% if server.variable('port') %}{{server.variable('port').defaultValue()}}{% endif %}
     username:
     password:
   topic:
@@ -42,7 +42,7 @@ mqtt:
 {% endif %}{% endfor %}
 {%- if asyncapi | isProtocol('kafka') %}
 kafka:
-  bootstrap-servers: {% for serverName, server in asyncapi.servers() %}{{server.url()}}{% if not loop.last %},{% endif %}{% endfor %}
+  bootstrap-servers: {% for serverName, server in asyncapi.servers() %}{% if server.variable('port') %}{{server.url() | replace('{port}', server.variable('port').defaultValue())}}{% else %}{{server.url()}}{% endif %}{% if not loop.last %},{% endif %}{% endfor %}
   {%- if hasPublish %}
   subscribe:
     pool-timeout: 3000


### PR DESCRIPTION
**Description**

- fix errors described in #13 
- fix not mentioned problems in Config.java generation for mqtt and amqp
- tested with:
```
servers:
  production:
    url: api.streetlights.smartylighting.com:{port}
    protocol: mqtt
    variables:
      port:
        default: '1883'
        enum:
          - '1883'
          - '8883'
  secondProd:
    url: api.rabbit.streetlights.smartylighting.com:{port}
    protocol: amqp
    variables:
      port:
        default: '5672'
        enum:
          - '5672'
          - '9999'

channels:
  smartylighting/streetlights/1/0/event/{streetlightId}/lighting/measured:
    parameters:
      streetlightId:
        $ref: '#/components/parameters/streetlightId'
    subscribe:
      bindings:
        amqp:
          exchange:
            name: my-queue-name
      operationId: receiveLightMeasurement
      message:
        $ref: '#/components/messages/lightMeasured'

  smartylighting/streetlights/1/0/action/{streetlightId}/turn/on:
    parameters:
      streetlightId:
        $ref: '#/components/parameters/streetlightId'
    publish:
      bindings:
        amqp:
          queue:
            name: my-queue-name
      operationId: turnOn
      message:
        $ref: '#/components/messages/turnOnOff'
```
take missed parts from common playground example.
 
**Related issue(s)**
Fixes #13 