### PR TITLE
feat: use new generic filters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .gradle
 node_modules
 output
+.DS_Store

--- a/.tp-config.json
+++ b/.tp-config.json
@@ -13,7 +13,7 @@
       "required": false
     }
   },
-  "generator": ">=0.40.1 <2.0.0",
+  "generator": ">=0.41.0 <2.0.0",
   "filters": [
     "@asyncapi/generator-filters"
   ]

--- a/.tp-config.json
+++ b/.tp-config.json
@@ -13,5 +13,8 @@
       "required": false
     }
   },
-  "generator": ">=0.40.1 <2.0.0"
+  "generator": ">=0.40.1 <2.0.0",
+  "filters": [
+    "@asyncapi/generator-filters"
+  ]
 }

--- a/filters/all.js
+++ b/filters/all.js
@@ -1,82 +1,75 @@
+const filter = module.exports;
 const _ = require('lodash');
 
-module.exports = ({ Nunjucks }) => {
-  Nunjucks.addFilter('camelCase', (str) => {
-    return _.camelCase(str);
-  });
+function toJavaType(str){
+  switch(str) {
+    case 'integer':
+    case 'int32':
+      return 'int';
+    case 'long':
+    case 'int64':
+      return 'long';
+    case 'boolean':
+      return 'boolean';
+    case 'date':
+      return 'java.time.LocalDate';
+    case 'dateTime':
+    case 'date-time':
+      return 'java.time.LocalDateTime';
+    case 'string':
+    case 'password':
+    case 'byte':
+      return 'String';
+    case 'float':
+      return 'float';
+    case 'double':
+      return 'double';
+    case 'binary':
+      return 'byte[]';
+    default:
+      return 'Object';
+  }
+}
+filter.toJavaType = toJavaType;
 
-  Nunjucks.addFilter('upperFirst', (str) => {
-    return _.upperFirst(str);
-  });
+function isProtocol(api, protocol){
+  return JSON.stringify(api.json()).includes('"protocol":"' + protocol + '"');
+};
+filter.isProtocol = isProtocol;
 
-  Nunjucks.addFilter('toJavaType', (str) => {
-    switch(str) {
-      case 'integer':
-      case 'int32':
-        return 'int';
-      case 'long':
-      case 'int64':
-        return 'long';
-      case 'boolean':
-        return 'boolean';
-      case 'date':
-        return 'java.time.LocalDate';
-      case 'dateTime':
-      case 'date-time':
-        return 'java.time.LocalDateTime';
-      case 'string':
-      case 'password':
-      case 'byte':
-        return 'String';
-      case 'float':
-        return 'float';
-      case 'double':
-        return 'double';
-      case 'binary':
-        return 'byte[]';
-      default:
-        return 'Object';
-    }
-  });
-
-  Nunjucks.addFilter('isProtocol', (api, protocol) => {
-    return JSON.stringify(api.json()).includes('"protocol":"' + protocol + '"');
-  });
-
-  Nunjucks.addFilter('print', (str) => {
-    console.error(str);
-  });
-
-  Nunjucks.addFilter('examplesToString', (ex) => {
-    let retStr = "";
-    ex.forEach(example => {
-      if (retStr !== "") {retStr += ", "}
-      if (typeof example == "object") {
-        try {
-          retStr += JSON.stringify(example);
-        } catch (ignore) {
-          retStr += example;
-        }
-      } else {
+function examplesToString(ex){
+  let retStr = "";
+  ex.forEach(example => {
+    if (retStr !== "") {retStr += ", "}
+    if (typeof example == "object") {
+      try {
+        retStr += JSON.stringify(example);
+      } catch (ignore) {
         retStr += example;
       }
-    });
-    return retStr;
-  });
-
-  Nunjucks.addFilter('splitByLines', (str) => {
-    if (str) {
-      return str.split(/\r?\n|\r/).filter((s) => s !== "");
     } else {
-      return "";
+      retStr += example;
     }
   });
-
-  Nunjucks.addFilter('isRequired', (name, list) => {
-    return list && list.includes(name);
-  });
-
-  Nunjucks.addFilter('schemeExists', (collection, scheme) => {
-    return _.some(collection, {'scheme': scheme});
-  });
+  return retStr;
 };
+filter.examplesToString = examplesToString;
+
+function splitByLines(str){
+  if (str) {
+    return str.split(/\r?\n|\r/).filter((s) => s !== "");
+  } else {
+    return "";
+  }
+};
+filter.splitByLines = splitByLines;
+
+function isRequired(name, list){
+  return list && list.includes(name);
+};
+filter.isRequired = isRequired;
+
+function schemeExists(collection, scheme){
+  return _.some(collection, {'scheme': scheme});
+};
+filter.schemeExists = schemeExists;

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,15 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@asyncapi/generator-filters": {
+      "version": "git+https://github.com/derberg/generator-filters.git#3926f2f7df14c18f34865d393399323d3dbd379a",
+      "from": "git+https://github.com/derberg/generator-filters.git#use-filters-lib",
+      "requires": {
+        "lodash": "^4.17.15",
+        "markdown-it": "^10.0.0",
+        "openapi-sampler": "^1.0.0-beta.15"
+      }
+    },
     "@babel/code-frame": {
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
@@ -612,6 +621,14 @@
       "integrity": "sha1-ZlWX3oap/+Oqm/vmyuXG6kJrSXk=",
       "dev": true
     },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "requires": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
     "argv-formatter": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/argv-formatter/-/argv-formatter-1.0.0.tgz",
@@ -1017,6 +1034,11 @@
         "once": "^1.4.0"
       }
     },
+    "entities": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.0.tgz",
+      "integrity": "sha512-D9f7V0JSRwIxlRI2mjMqufDrRDnx8p+eEOz7aUM9SuvF8gsBzra0/6tbjl1m8eQHrZlYj6PxqE00hZ1SAIKPLw=="
+    },
     "env-ci": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/env-ci/-/env-ci-5.0.2.tgz",
@@ -1205,6 +1227,11 @@
       "requires": {
         "semver-regex": "^2.0.0"
       }
+    },
+    "foreach": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
     },
     "from2": {
       "version": "2.3.0",
@@ -1543,6 +1570,14 @@
       "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
       "dev": true
     },
+    "json-pointer": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/json-pointer/-/json-pointer-0.6.0.tgz",
+      "integrity": "sha1-jlAFUKaqxUZKRzN32leqbMIoKNc=",
+      "requires": {
+        "foreach": "^2.0.4"
+      }
+    },
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
@@ -1570,6 +1605,14 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
       "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
       "dev": true
+    },
+    "linkify-it": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.2.0.tgz",
+      "integrity": "sha512-GnAl/knGn+i1U/wjBz3akz2stz+HrHLsxMwHQGofCDfPvlf+gDKN58UtfmUquTY4/MXeE2x7k19KQmeoZi94Iw==",
+      "requires": {
+        "uc.micro": "^1.0.1"
+      }
     },
     "load-json-file": {
       "version": "4.0.0",
@@ -1671,6 +1714,18 @@
       "integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk=",
       "dev": true
     },
+    "markdown-it": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-10.0.0.tgz",
+      "integrity": "sha512-YWOP1j7UbDNz+TumYP1kpwnP0aEa711cJjrAQrzd0UXlbJfc5aAq0F/PZHjiioqDC1NKgvIMX+o+9Bk7yuM2dg==",
+      "requires": {
+        "argparse": "^1.0.7",
+        "entities": "~2.0.0",
+        "linkify-it": "^2.0.0",
+        "mdurl": "^1.0.1",
+        "uc.micro": "^1.0.5"
+      }
+    },
     "marked": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/marked/-/marked-0.8.2.tgz",
@@ -1742,6 +1797,11 @@
           }
         }
       }
+    },
+    "mdurl": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
+      "integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4="
     },
     "meow": {
       "version": "5.0.0",
@@ -5441,6 +5501,14 @@
         "mimic-fn": "^2.1.0"
       }
     },
+    "openapi-sampler": {
+      "version": "1.0.0-beta.15",
+      "resolved": "https://registry.npmjs.org/openapi-sampler/-/openapi-sampler-1.0.0-beta.15.tgz",
+      "integrity": "sha512-wUD/vD3iBHKik/sME3uwUu4X3HFA53rDrPcVvLzgEELjHLbnTpSYfm4Jo9qZT1dPfBRowAnrF/VRQfOjL5QRAw==",
+      "requires": {
+        "json-pointer": "^0.6.0"
+      }
+    },
     "optimist": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
@@ -6162,6 +6230,11 @@
         }
       }
     },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+    },
     "stream-combiner2": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.1.1.tgz",
@@ -6352,6 +6425,11 @@
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
       "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
       "dev": true
+    },
+    "uc.micro": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
+      "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA=="
     },
     "uglify-js": {
       "version": "3.8.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,8 +5,9 @@
   "requires": true,
   "dependencies": {
     "@asyncapi/generator-filters": {
-      "version": "git+https://github.com/derberg/generator-filters.git#3926f2f7df14c18f34865d393399323d3dbd379a",
-      "from": "git+https://github.com/derberg/generator-filters.git#use-filters-lib",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@asyncapi/generator-filters/-/generator-filters-1.0.0.tgz",
+      "integrity": "sha512-LcqLwUh/PqcHzIyEWxPT3pIehzif8d7aVq/CBWx0Hni7x/jsEbQhvtgT8LQpwHFLTZrNAKuxGivzOk3Ero+SQQ==",
       "requires": {
         "lodash": "^4.17.15",
         "markdown-it": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "access": "public"
   },
   "dependencies": {
-    "lodash": "^4.17.15"
+    "lodash": "^4.17.15",
+    "@asyncapi/generator-filters": "https://github.com/derberg/generator-filters#use-filters-lib"
   },
   "devDependencies": {
     "@semantic-release/commit-analyzer": "^8.0.1",

--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
     "access": "public"
   },
   "dependencies": {
-    "lodash": "^4.17.15",
-    "@asyncapi/generator-filters": "https://github.com/derberg/generator-filters#use-filters-lib"
+    "@asyncapi/generator-filters": "^1.0.0",
+    "lodash": "^4.17.15"
   },
   "devDependencies": {
     "@semantic-release/commit-analyzer": "^8.0.1",


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- use generic filters library
- modify and cleanup of local filters for new testable style
- removed filters that are already in the generator-filters
- I removed the filter that was not used, `print`, you can use in future filter from generator-filters library called `logError`

It looks like a lot of changes, but don't worry, I did not touch the logic. Some filters are removed but only because they are available thanks to the new generator-filter library

**Related issue(s)**
See also https://github.com/asyncapi/generator/issues/212