### PR TITLE
feat: migrate to latest generator enabling usage of reusable hooks

### DIFF
--- a/.tp-config.json
+++ b/.tp-config.json
@@ -13,7 +13,7 @@
       "required": false
     }
   },
-  "generator": ">=0.41.0 <2.0.0",
+  "generator": ">=0.46.0 <2.0.0",
   "filters": [
     "@asyncapi/generator-filters"
   ]

--- a/hooks/addApiFile.js
+++ b/hooks/addApiFile.js
@@ -1,8 +1,8 @@
 const fs = require('fs');
 const path = require('path');
 
-module.exports = register => {
-    register('generate:after', generator => {
+module.exports = {
+    'generate:after': generator => {
         const asyncapi = generator.originalAsyncAPI;
         let extension;
 
@@ -14,5 +14,5 @@ module.exports = register => {
         }
 
         fs.writeFileSync(path.resolve(generator.targetDir, `src/main/resources/api/asyncAPI.${extension}`), asyncapi);
-    });
+    }
 };

--- a/hooks/fixModelFileNames.js
+++ b/hooks/fixModelFileNames.js
@@ -2,8 +2,8 @@ const fs = require('fs');
 const path = require('path');
 const _ = require('lodash');
 
-module.exports = register => {
-    register('generate:after', generator => {
+module.exports = {
+    'generate:after': generator => {
         const asyncapi = generator.asyncapi;
         const messages = asyncapi.allMessages();
         const schemas = asyncapi.allSchemas();
@@ -20,5 +20,5 @@ module.exports = register => {
                     path.resolve(generator.targetDir, `src/main/java/com/asyncapi/model/${_.upperFirst(key)}.java`));
             }
         }
-    });
+    }
 };

--- a/hooks/removeNotRelevantParts.js
+++ b/hooks/removeNotRelevantParts.js
@@ -1,8 +1,8 @@
 const fs = require('fs');
 const path = require('path');
 
-module.exports = register => {
-    register('generate:after', generator => {
+module.exports = {
+    'generate:after': generator => {
         let hasMqtt, hasAmqp, hasKafka;
         const asyncapi = generator.asyncapi;
         for (let server of Object.values(asyncapi.servers())) {
@@ -21,5 +21,5 @@ module.exports = register => {
         if (!hasMqtt) {
             // remove filers from template related only to mqtt
         }
-    });
+    }
 };


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- migrate to latest generator enabling usage of reusable hooks
- hooks functions refactor to new approach

Test by:
- installing latest generator `npm install @asyncapi/generator -g`
- generate using fork `ag asyncapi.yml https://github.com/derberg/java-spring-template#refactor-hooks -o output --force-write`

What this change gives to template dev:
- write reusable hooks or just use hooks from official asyncapi library to DRY
  - https://github.com/asyncapi/generator/blob/master/docs/authoring.md#hooks
  - https://github.com/asyncapi/generator-hooks/#using-hooks-library-in-custom-template

**Related issue(s)**
See also https://github.com/asyncapi/generator/issues/318