### PR TITLE
feat: add generation of equals and hashCode to the model

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ components:
 
 |Name|Description|Required|Default|
 |---|---|---|---|
+|disableEqualsHashCode|Disable generation of equals and hashCode methods for model classes.|No|`false`|
 |listenerPollTimeout|Only for Kafka. Timeout in ms to use when polling the consumer.|No|`3000`|
 |listenerConcurrency|Only for Kafka. Number of threads to run in the listener containers.|No|`3`|
 |asyncapiFileDir| Path where original AsyncAPI file will be stored.|No|`src/main/resources/api/`|

--- a/package.json
+++ b/package.json
@@ -71,6 +71,11 @@
       "**/*.jar"
     ],
     "parameters": {
+      "disableEqualsHashCode": {
+        "description": "Disable generation of equals and hashCode methods for model classes.",
+        "default": "false",
+        "required": false
+      },
       "listenerPollTimeout": {
         "description": "Only for Kafka. Timeout to use when polling the consumer.",
         "default": 3000,

--- a/template/src/main/java/com/asyncapi/model/$$message$$.java
+++ b/template/src/main/java/com/asyncapi/model/$$message$$.java
@@ -1,5 +1,7 @@
 package com.asyncapi.model;
 
+import java.util.Objects;
+
 {% if message.description() or message.examples()%}/**{% for line in message.description() | splitByLines %}
  * {{ line | safe}}{% endfor %}{% if message.examples() %}
  * Examples: {{message.examples() | examplesToString | safe}}{% endif %}
@@ -15,4 +17,21 @@ public class {{messageName | camelCase | upperFirst}} {
     public void setPayload({{payloadName}} payload) {
         this.payload = payload;
     }
+
+    {% if params.disableEqualsHashCode === 'false' %}@Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        {{messageName | camelCase | upperFirst}} event = ({{messageName | camelCase | upperFirst}}) o;
+        return Objects.equals(this.payload, event.payload);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(payload);
+    }{% endif %}
 }

--- a/template/src/main/java/com/asyncapi/model/$$schema$$.java
+++ b/template/src/main/java/com/asyncapi/model/$$schema$$.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import java.util.Arrays;
 import java.util.Objects;
 
 {% if schema.description() or schema.examples() %}/**{% for line in schema.description() | splitByLines %}
@@ -109,4 +110,21 @@ public class {{schemaName | camelCase | upperFirst}} {
         this.{{varName}} = {{varName}};
     }
     {% endfor %}
+    {% if params.disableEqualsHashCode === 'false' %}@Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        {{schemaName | camelCase | upperFirst}} {{schemaName | camelCase}} = ({{schemaName | camelCase | upperFirst}}) o;
+        return {% for propName, prop in schema.properties() %}{% set varName = propName | camelCase %}{% if prop.type() === 'array' %}{% set varName = propName | camelCase + 'Array' %}{% endif %}
+            {% if prop.type() === 'array' %}Arrays{% else %}Objects{% endif %}.equals(this.{{varName}}, {{schemaName | camelCase}}.{{varName}}){% if not loop.last %} &&{% else %};{% endif %}{% endfor %}
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash({% for propName, prop in schema.properties() %}{{propName | camelCase}}{% if prop.type() === 'array' %}Array{% endif %}{% if not loop.last %}, {% endif %}{% endfor %});
+    }{% endif %}
 }


### PR DESCRIPTION
**Description**

- by default equals and hashCode are override, it could be disabled by flag

**Related issue(s)**
Resolves: #47
<!-- If you refer to a particular issue, provide its number, othewise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->