### PR TITLE
feat: add param to control java package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ components:
 |listenerPollTimeout|Only for Kafka. Timeout in ms to use when polling the consumer.|No|`3000`|
 |listenerConcurrency|Only for Kafka. Number of threads to run in the listener containers.|No|`3`|
 |asyncapiFileDir| Path where original AsyncAPI file will be stored.|No|`src/main/resources/api/`|
-
+|javaPackage|The Java package of the generated classes. Alternatively you can set the specification extension `info.x-java-package`. If both extension and parameter are used, parameter has more priority.|No|`com.asyncapi`|
 #### Examples
 
 The shortest possible syntax:

--- a/hooks/packageProcessor.js
+++ b/hooks/packageProcessor.js
@@ -1,0 +1,45 @@
+const fs = require('fs-extra');
+
+module.exports = {
+    /**
+     * Move directory with source code to specified.
+     *
+     * @param generator
+     */
+    'generate:after': generator => {
+        const sourcePath = generator.targetDir + '/src/main/java/';
+        const testPath = generator.targetDir + '/src/test/java/';
+        let javaPackage = generator.templateParams['userJavaPackage'];
+
+        javaPackage = javaPackage.replace(/\./g, '/');
+
+        if (javaPackage !== 'com/asyncapi') {
+            fs.moveSync(sourcePath + 'com/asyncapi', sourcePath + javaPackage);
+            fs.moveSync(testPath + 'com/asyncapi', testPath + javaPackage);
+            fs.removeSync(sourcePath + 'com');
+            fs.removeSync(testPath + 'com');
+        }
+    },
+
+    /**
+     * If parameters wasn't pass, but extension is used, then set extension to param value.
+     * Since template params are not modifiable, another param used to store updated value.
+     *
+     * @param generator
+     */
+    'generate:before': generator => {
+        const extensions = generator.asyncapi.info().extensions();
+        let javaPackage = generator.templateParams['javaPackage'];
+
+        if (javaPackage === 'com.asyncapi' && extensions && extensions['x-java-package']) {
+            javaPackage = extensions['x-java-package'];
+        }
+
+        Object.defineProperty(generator.templateParams, 'userJavaPackage', {
+            enumerable: true,
+            get() {
+                return javaPackage;
+            }
+        });
+    }
+};

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "dependencies": {
     "@asyncapi/generator-filters": "^1.0.0",
     "@asyncapi/generator-hooks": "^0.1.0",
+    "fs-extra": "^9.0.0",
     "lodash": "^4.17.15"
   },
   "devDependencies": {
@@ -84,6 +85,11 @@
       "asyncapiFileDir": {
         "description": "Parameter of @asyncapi/generator-hooks#createAsyncapiFile, allows to specify where original AsyncAPI file will be stored.",
         "default": "src/main/resources/api/",
+        "required": false
+      },
+      "javaPackage": {
+        "description": "The Java package of the generated classes. Alternatively you can set the specification extension info.x-java-package",
+        "default": "com.asyncapi",
         "required": false
       }
     },

--- a/partials/AmqpConfig.java
+++ b/partials/AmqpConfig.java
@@ -1,7 +1,6 @@
-{% macro amqpConfig(asyncapi) %}
-package com.asyncapi.infrastructure;
+{% macro amqpConfig(asyncapi, params) %}
 
-import com.asyncapi.service.MessageHandlerService;
+import {{params['userJavaPackage']}}.service.MessageHandlerService;
 import org.springframework.amqp.core.*;
 import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;

--- a/partials/CommonPublisher.java
+++ b/partials/CommonPublisher.java
@@ -1,5 +1,4 @@
 {% macro commonPublisher(asyncapi) %}
-package com.asyncapi.service;
 
 import org.springframework.integration.annotation.Gateway;
 import org.springframework.integration.annotation.MessagingGateway;

--- a/partials/KafkaConfig.java
+++ b/partials/KafkaConfig.java
@@ -1,4 +1,4 @@
-{% macro kafkaConfig(asyncapi) %}
+{% macro kafkaConfig(asyncapi, params) %}
 {%- set hasSubscribe = false -%}
 {%- set hasPublish = false -%}
 {%- for channelName, channel in asyncapi.channels() -%}
@@ -8,8 +8,7 @@
     {%- if channel.hasSubscribe() -%}
         {%- set hasSubscribe = true -%}
     {%- endif -%}
-{%- endfor -%}
-package com.asyncapi.infrastructure;
+{%- endfor %}
 
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
@@ -62,7 +61,7 @@ public class Config {
         props.put(JsonSerializer.TYPE_MAPPINGS,
     {%- for schema in asyncapi.allSchemas().values() | isObjectType %}
         {%- if schema.uid() | first !== '<' and schema.type() === 'object' %}
-        "{{schema.uid()}}:com.asyncapi.model.{{schema.uid() | camelCase | upperFirst}}{% if not loop.last %}," +{% else %}"{% endif %}
+        "{{schema.uid()}}:{{params['userJavaPackage']}}.model.{{schema.uid() | camelCase | upperFirst}}{% if not loop.last %}," +{% else %}"{% endif %}
         {% endif -%}
     {% endfor -%}
         );
@@ -96,11 +95,11 @@ public class Config {
         props.put(JsonDeserializer.TYPE_MAPPINGS,
     {%- for schema in asyncapi.allSchemas().values() | isObjectType %}
         {%- if schema.uid() | first !== '<' and schema.type() === 'object' %}
-        "{{schema.uid()}}:com.asyncapi.model.{{schema.uid() | camelCase | upperFirst}}{% if not loop.last %}," +{% else %}"{% endif %}
+        "{{schema.uid()}}:{{params['userJavaPackage']}}.model.{{schema.uid() | camelCase | upperFirst}}{% if not loop.last %}," +{% else %}"{% endif %}
         {% endif -%}
     {% endfor -%}
         );
-        props.put(JsonDeserializer.TRUSTED_PACKAGES, "com.asyncapi.model");
+        props.put(JsonDeserializer.TRUSTED_PACKAGES, "{{params['userJavaPackage']}}.model");
         return props;
     }
 {% endif %}

--- a/partials/KafkaPublisher.java
+++ b/partials/KafkaPublisher.java
@@ -1,5 +1,4 @@
-{% macro kafkaPublisher(asyncapi) %}
-package com.asyncapi.service;
+{% macro kafkaPublisher(asyncapi, params) %}
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.kafka.core.KafkaTemplate;
@@ -9,7 +8,7 @@ import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.stereotype.Service;
 {% for channelName, channel in asyncapi.channels() %}
         {%- if channel.hasSubscribe() %}
-import com.asyncapi.model.{{channel.subscribe().message().payload().uid() | camelCase | upperFirst}};
+import {{params['userJavaPackage']}}.model.{{channel.subscribe().message().payload().uid() | camelCase | upperFirst}};
     {% endif -%}
 {% endfor %}
 

--- a/partials/MqttConfig.java
+++ b/partials/MqttConfig.java
@@ -1,7 +1,6 @@
-{% macro mqttConfig(asyncapi) %}
-package com.asyncapi.infrastructure;
+{% macro mqttConfig(asyncapi, params) %}
 
-import com.asyncapi.service.MessageHandlerService;
+import {{params['userJavaPackage']}}.service.MessageHandlerService;
 import org.eclipse.paho.client.mqttv3.MqttConnectOptions;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;

--- a/template/build.gradle
+++ b/template/build.gradle
@@ -4,8 +4,8 @@ plugins {
 	id 'java'
 }
 
-group = 'com.asyncapi'
-version = '0.0.1-SNAPSHOT'
+group = "{{ params['userJavaPackage'] }}"
+version = "0.0.1-SNAPSHOT"
 sourceCompatibility = JavaVersion.VERSION_1_8
 
 repositories {

--- a/template/src/main/java/com/asyncapi/Application.java
+++ b/template/src/main/java/com/asyncapi/Application.java
@@ -1,4 +1,4 @@
-package com.asyncapi;
+package {{ params['userJavaPackage'] }};
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;

--- a/template/src/main/java/com/asyncapi/infrastructure/Config.java
+++ b/template/src/main/java/com/asyncapi/infrastructure/Config.java
@@ -1,13 +1,15 @@
+package {{ params['userJavaPackage'] }}.infrastructure;
+
 {%- from "partials/AmqpConfig.java" import amqpConfig -%}
 {%- from "partials/MqttConfig.java" import mqttConfig -%}
 {%- from "partials/KafkaConfig.java" import kafkaConfig -%}
 
 {%- if asyncapi | isProtocol('amqp') -%}
-{{- amqpConfig(asyncapi) -}}
+{{- amqpConfig(asyncapi, params) -}}
 {%- endif -%}
 {%- if asyncapi | isProtocol('mqtt') -%}
-{{- mqttConfig(asyncapi) -}}
+{{- mqttConfig(asyncapi, params) -}}
 {%- endif -%}
 {%- if asyncapi | isProtocol('kafka') -%}
-{{- kafkaConfig(asyncapi) -}}
+{{- kafkaConfig(asyncapi, params) -}}
 {%- endif -%}

--- a/template/src/main/java/com/asyncapi/model/$$message$$.java
+++ b/template/src/main/java/com/asyncapi/model/$$message$$.java
@@ -1,4 +1,4 @@
-package com.asyncapi.model;
+package {{ params['userJavaPackage'] }}.model;
 
 {% if message.description() or message.examples()%}/**{% for line in message.description() | splitByLines %}
  * {{ line | safe}}{% endfor %}{% if message.examples() %}

--- a/template/src/main/java/com/asyncapi/model/$$schema$$.java
+++ b/template/src/main/java/com/asyncapi/model/$$schema$$.java
@@ -1,4 +1,4 @@
-package com.asyncapi.model;
+package {{ params['userJavaPackage'] }}.model;
 
 import javax.validation.constraints.*;
 import javax.validation.Valid;

--- a/template/src/main/java/com/asyncapi/service/CommandLinePublisher.java
+++ b/template/src/main/java/com/asyncapi/service/CommandLinePublisher.java
@@ -1,4 +1,4 @@
-package com.asyncapi.service;
+package {{ params['userJavaPackage'] }}.service;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.CommandLineRunner;
@@ -18,7 +18,7 @@ public class CommandLinePublisher implements CommandLineRunner {
 
         {%- for channelName, channel in asyncapi.channels() %}
             {%- if channel.hasSubscribe() %}
-        publisherService.{{channel.subscribe().id() | camelCase}}({% if asyncapi | isProtocol('kafka') %}(new Random()).nextInt(), new com.asyncapi.model.{{channel.subscribe().message().payload().uid() | camelCase | upperFirst}}(){% else %}"Hello World from {{channelName}}"{% endif %});
+        publisherService.{{channel.subscribe().id() | camelCase}}({% if asyncapi | isProtocol('kafka') %}(new Random()).nextInt(), new {{ params['userJavaPackage'] }}.model.{{channel.subscribe().message().payload().uid() | camelCase | upperFirst}}(){% else %}"Hello World from {{channelName}}"{% endif %});
             {% endif -%}
         {%- endfor %}
         System.out.println("Message sent");

--- a/template/src/main/java/com/asyncapi/service/MessageHandlerService.java
+++ b/template/src/main/java/com/asyncapi/service/MessageHandlerService.java
@@ -1,4 +1,4 @@
-package com.asyncapi.service;
+package {{ params['userJavaPackage'] }}.service;
 {%- set hasSubscribe = false -%}
 {%- set hasPublish = false -%}
 {%- for channelName, channel in asyncapi.channels() -%}
@@ -21,7 +21,7 @@ import org.springframework.messaging.handler.annotation.Header;
 import org.springframework.messaging.handler.annotation.Payload;
     {% for channelName, channel in asyncapi.channels() %}
         {%- if channel.hasPublish() %}
-import com.asyncapi.model.{{channel.publish().message().payload().uid() | camelCase | upperFirst}};
+import {{ params['userJavaPackage'] }}.model.{{channel.publish().message().payload().uid() | camelCase | upperFirst}};
         {% endif -%}
     {% endfor -%}
 {% endif %}

--- a/template/src/main/java/com/asyncapi/service/PublisherService.java
+++ b/template/src/main/java/com/asyncapi/service/PublisherService.java
@@ -1,7 +1,8 @@
+package {{ params['userJavaPackage'] }}.service;
 {%- from "partials/CommonPublisher.java" import commonPublisher -%}
 {%- from "partials/KafkaPublisher.java" import kafkaPublisher -%}
 {%- if asyncapi | isProtocol('kafka') -%}
-{{- kafkaPublisher(asyncapi) -}}
+{{- kafkaPublisher(asyncapi, params) -}}
 {%- else -%}
 {{- commonPublisher(asyncapi) -}}
 {%- endif -%}

--- a/template/src/test/java/com/asyncapi/ApplicationTests.java
+++ b/template/src/test/java/com/asyncapi/ApplicationTests.java
@@ -1,4 +1,4 @@
-package com.asyncapi;
+package {{ params['userJavaPackage'] }};
 
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/template/src/test/java/com/asyncapi/SimpleKafkaTest.java
+++ b/template/src/test/java/com/asyncapi/SimpleKafkaTest.java
@@ -8,15 +8,15 @@
         {%- set hasSubscribe = true -%}
     {%- endif -%}
 {%- endfor -%}
-package com.asyncapi;
+package {{ params['userJavaPackage'] }};
 
 {% for channelName, channel in asyncapi.channels() %} {% if channel.hasSubscribe() %}
-import com.asyncapi.model.{{channel.subscribe().message().payload().uid() | camelCase | upperFirst}};
+import {{ params['userJavaPackage'] }}.model.{{channel.subscribe().message().payload().uid() | camelCase | upperFirst}};
 {% endif %} {% endfor %}
 {% for channelName, channel in asyncapi.channels() %} {% if channel.hasPublish() %}
-import com.asyncapi.model.{{channel.publish().message().payload().uid() | camelCase | upperFirst}};
+import {{ params['userJavaPackage'] }}.model.{{channel.publish().message().payload().uid() | camelCase | upperFirst}};
 {% endif %} {% endfor %}
-{% if hasSubscribe %}import com.asyncapi.service.PublisherService;{% endif %}
+{% if hasSubscribe %}import {{ params['userJavaPackage'] }}.service.PublisherService;{% endif %}
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;

--- a/template/src/test/java/com/asyncapi/TestcontainerKafkaTest.java
+++ b/template/src/test/java/com/asyncapi/TestcontainerKafkaTest.java
@@ -8,15 +8,15 @@
         {%- set hasSubscribe = true -%}
     {%- endif -%}
 {%- endfor -%}
-package com.asyncapi;
+package {{ params['userJavaPackage'] }};
 
 {% for channelName, channel in asyncapi.channels() %} {% if channel.hasSubscribe() %}
-import com.asyncapi.model.{{channel.subscribe().message().payload().uid() | camelCase | upperFirst}};
+import {{ params['userJavaPackage'] }}.model.{{channel.subscribe().message().payload().uid() | camelCase | upperFirst}};
 {% endif %} {% endfor %}
 {% for channelName, channel in asyncapi.channels() %} {% if channel.hasPublish() %}
-import com.asyncapi.model.{{channel.publish().message().payload().uid() | camelCase | upperFirst}};
+import {{ params['userJavaPackage'] }}.model.{{channel.publish().message().payload().uid() | camelCase | upperFirst}};
 {% endif %} {% endfor %}
-{% if hasSubscribe %}import com.asyncapi.service.PublisherService;{% endif %}
+{% if hasSubscribe %}import {{ params['userJavaPackage'] }}.service.PublisherService;{% endif %}
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;


### PR DESCRIPTION
**Description**

- New parameter to set user specific java package name
- Idea of extension from java-spring-cloud-stream template supported

**Related issue(s)**
Resolves: #45 
<!-- If you refer to a particular issue, provide its number, othewise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->