### PR TITLE
fix: generation broken if javaPackage param starts with com

### DIFF
--- a/hooks/05_packageProcessor.js
+++ b/hooks/05_packageProcessor.js
@@ -1,4 +1,5 @@
 const fs = require('fs-extra');
+const tmp = require('tmp');
 
 module.exports = {
     /**
@@ -14,10 +15,15 @@ module.exports = {
         javaPackage = javaPackage.replace(/\./g, '/');
 
         if (javaPackage !== 'com/asyncapi') {
-            fs.moveSync(sourcePath + 'com/asyncapi', sourcePath + javaPackage);
-            fs.moveSync(testPath + 'com/asyncapi', testPath + javaPackage);
+            const tmpSrc = tmp.dirSync();
+            const tmpTest = tmp.dirSync();
+            fs.copySync(sourcePath + 'com/asyncapi', tmpSrc.name);
+            fs.copySync(testPath + 'com/asyncapi', tmpTest.name);
             fs.removeSync(sourcePath + 'com');
             fs.removeSync(testPath + 'com');
+            fs.copySync(tmpSrc.name, sourcePath + javaPackage);
+            fs.copySync(tmpTest.name, testPath + javaPackage);
+            tmp.setGracefulCleanup();
         }
     },
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6450,6 +6450,24 @@
         "readable-stream": "2 || 3"
       }
     },
+    "tmp": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
+      "integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
+      "requires": {
+        "rimraf": "^3.0.0"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
+      }
+    },
     "to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "@asyncapi/generator-filters": "^1.0.0",
     "@asyncapi/generator-hooks": "^0.1.0",
     "fs-extra": "^9.0.0",
-    "lodash": "^4.17.15"
+    "lodash": "^4.17.15",
+    "tmp": "^0.2.1"
   },
   "devDependencies": {
     "@semantic-release/commit-analyzer": "^8.0.1",


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- bug description in #65 
- tested with:
- `-p javaPackage=com.test`
- `-p javaPackage=org.test`
- `-p javaPackage=com.asyncapi.test`

**Related issue(s)**
Resolves #65 
<!-- If you refer to a particular issue, provide its number, othewise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->