### PR TITLE
feat: add allOf support

### DIFF
--- a/filters/all.js
+++ b/filters/all.js
@@ -1,6 +1,44 @@
 const filter = module.exports;
 const _ = require('lodash');
 
+function defineType(prop) {
+    if (prop.type() === 'object') {
+        return _.upperFirst(_.camelCase(prop.uid()));
+    } else if (prop.type() === 'array') {
+        if (prop.items().format()) {
+            return toJavaType(prop.items().format()) + '[]';
+        } else {
+            return toJavaType(prop.items().type()) + '[]';
+        }
+    } else if (prop.enum() && (prop.type() === 'string' || prop.type() === 'integer')) {
+            return _.upperFirst(_.camelCase(propName)) + 'Enum';
+    } else if (prop.anyOf() || prop.oneOf()) {
+        let propType = 'OneOf';
+        let hasPrimitive = false;
+        [].concat(prop.anyOf(), prop.oneOf()).filter(obj != null).forEach(obj => {
+            hasPrimitive |= obj.type() !== 'object';
+            propType += _.upperFirst(_.camelCase(obj.uid()));
+        });
+        if (hasPrimitive) {
+            propType = 'Object';
+        }
+        return propType;
+    } else if (prop.allOf()) {
+        let propType = 'AllOf';
+        prop.allOf().forEach(obj => {
+            propType += _.upperFirst(_.camelCase(obj.uid()));
+        });
+        return propType;
+    } else {
+        if (prop.format()) {
+            return toJavaType(prop.format());
+        } else {
+            return toJavaType(prop.type());
+        }
+    }
+}
+filter.defineType = defineType;
+
 function toJavaType(str){
   switch(str) {
     case 'integer':

--- a/filters/all.js
+++ b/filters/all.js
@@ -1,7 +1,7 @@
 const filter = module.exports;
 const _ = require('lodash');
 
-function defineType(prop) {
+function defineType(prop, propName) {
     if (prop.type() === 'object') {
         return _.upperFirst(_.camelCase(prop.uid()));
     } else if (prop.type() === 'array') {

--- a/template/src/main/java/com/asyncapi/model/$$message$$.java
+++ b/template/src/main/java/com/asyncapi/model/$$message$$.java
@@ -1,6 +1,7 @@
 package {{ params['userJavaPackage'] }}.model;
 
 import java.util.Objects;
+import javax.validation.Valid;
 
 {% if message.description() or message.examples()%}/**{% for line in message.description() | splitByLines %}
  * {{ line | safe}}{% endfor %}{% if message.examples() %}
@@ -24,10 +25,35 @@ public class {{messageName | camelCase | upperFirst}} {
 
     }
         {%- endif %}
-    {%- else %}
+    {%- elif message.payload().allOf() %}
+        {%- set payloadName = 'AllOf' %}
+        {%- for obj in message.payload().allOf() %}
+            {%- set payloadName = payloadName + obj.uid() | camelCase | upperFirst %}
+        {%- endfor %}
+    public class {{payloadName}} {
+        {%- for obj in message.payload().allOf() %}
+            {%- set varName = obj.uid() | camelCase %}
+            {%- set className = obj.uid() | camelCase | upperFirst %}
+            {%- set propType = obj | defineType %}
+
+            {%- if obj.type() === 'array' %}
+                {%- set varName = obj.uid() | camelCase + 'Array' %}
+            {%- endif %}
+        private @Valid {{propType}} {{varName}};
+
+        public {{propType}} get{{className}}() {
+            return {{varName}};
+        }
+
+        public void set{{className}}({{propType}} {{varName}}) {
+            this.{{varName}} = {{varName}};
+        }
+        {%- endfor %}
+    }
+    {% else %}
         {%- set payloadName = message.payload().uid() | camelCase | upperFirst %}
     {%- endif %}
-    private {{payloadName}} payload;
+    private @Valid {{payloadName}} payload;
 
     public {{payloadName}} getPayload() {
         return payload;

--- a/template/src/main/java/com/asyncapi/model/$$message$$.java
+++ b/template/src/main/java/com/asyncapi/model/$$message$$.java
@@ -34,7 +34,7 @@ public class {{messageName | camelCase | upperFirst}} {
         {%- for obj in message.payload().allOf() %}
             {%- set varName = obj.uid() | camelCase %}
             {%- set className = obj.uid() | camelCase | upperFirst %}
-            {%- set propType = obj | defineType %}
+            {%- set propType = obj | defineType(obj.uid()) %}
 
             {%- if obj.type() === 'array' %}
                 {%- set varName = obj.uid() | camelCase + 'Array' %}

--- a/template/src/main/java/com/asyncapi/model/$$objectSchema$$.java
+++ b/template/src/main/java/com/asyncapi/model/$$objectSchema$$.java
@@ -88,7 +88,7 @@ public class {{schemaName | camelCase | upperFirst}} {
             {%- for obj in prop.allOf() %}
                 {%- set varName = obj.uid() | camelCase %}
                 {%- set className = obj.uid() | camelCase | upperFirst %}
-                {%- set propType = obj | defineType %}
+                {%- set propType = obj | defineType(obj.uid()) %}
 
                 {%- if obj.type() === 'array' %}
                     {%- set varName = obj.uid() | camelCase + 'Array' %}
@@ -118,7 +118,7 @@ public class {{schemaName | camelCase | upperFirst}} {
     {% for propName, prop in schema.properties() %}
         {%- set varName = propName | camelCase %}
         {%- set className = propName | camelCase | upperFirst %}
-        {%- set propType = prop | defineType %}
+        {%- set propType = prop | defineType(propName) %}
 
         {%- if prop.type() === 'array' %}
             {%- set varName = propName | camelCase + 'Array' %}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

Add support of `allOf` definition for schema model. Implementation made as aggregation of types.
Tested with 
```
asyncapi: '2.0.0'
info:
  title: allOf example
  version: '1.0.0'

channels:
  test:
    publish:
      message:
        $ref: '#/components/messages/testMessages'
    subscribe:
      message:
        $ref: '#/components/messages/testMessages2'

components:
  messages:
    testMessages:
      payload:
        allOf: # allOf in payload schema
          - $ref: "#/components/schemas/objectWithKey"
          - $ref: "#/components/schemas/objectWithKey2"
    testMessages2:
      payload:
        allOf: # allOf in payload schema
          - $ref: "#/components/schemas/objectWithKey"
          - type: string

  schemas:
    objectWithKey:
      type: object
      properties:
        key:
          allOf:
            - $ref: "#/components/schemas/objectWithKey3"
            - $ref: "#/components/schemas/objectWithKey2"
    objectWithKey2:
      type: object
      properties:
        key2:
          type: string
    objectWithKey3:
      type: object
      properties:
        key3:
          allOf:
            - $ref: "#/components/schemas/objectWithKey4"
            - type: string
    objectWithKey4:
      type: object
      properties:
        key4:
          type: string
```

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number, othewise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->
Resolves: #90 