### PR TITLE
fix: support time zones for json time formats 

### DIFF
--- a/filters/all.js
+++ b/filters/all.js
@@ -13,9 +13,11 @@ function toJavaType(str){
       return 'boolean';
     case 'date':
       return 'java.time.LocalDate';
+    case 'time':
+      return 'java.time.OffsetTime';
     case 'dateTime':
     case 'date-time':
-      return 'java.time.LocalDateTime';
+      return 'java.time.OffsetDateTime';
     case 'string':
     case 'password':
     case 'byte':


### PR DESCRIPTION
**Description**
`format: time` and `format: date-time` of `type: string` has time zone.
Now `OffsetTime` and `OffsetDateTime` classes are used to present these formats in generated model.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number, othewise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->
Resolves: #95 