### PR TITLE
fix: filter out properly null objects in oneOf and anyOf

### DIFF
--- a/filters/all.js
+++ b/filters/all.js
@@ -17,7 +17,7 @@ function defineType(prop, propName) {
     } else if (prop.anyOf() || prop.oneOf()) {
         let propType = 'OneOf';
         let hasPrimitive = false;
-        [].concat(prop.anyOf(), prop.oneOf()).filter(obj != null).forEach(obj => {
+        [].concat(prop.anyOf(), prop.oneOf()).filter(obj => obj != null).forEach(obj => {
             hasPrimitive |= obj.type() !== 'object';
             propType += _.upperFirst(_.camelCase(obj.uid()));
         });


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- filter out properly null objects in oneOF and anyOf

**Related issue(s)**
Fixes #108