### PR TITLE
fix: remove \ from \\ in regex patterns for @Pattern annotation

### DIFF
--- a/filters/all.js
+++ b/filters/all.js
@@ -161,3 +161,9 @@ function createEnum(val){
   return result;
 };
 filter.createEnum = createEnum;
+
+function addBackSlashToPattern(val) {  
+  let result = val.replace(/\\/g, "\\\\");
+  return result;
+}
+filter.addBackSlashToPattern = addBackSlashToPattern;

--- a/template/src/main/java/com/asyncapi/model/$$objectSchema$$.java
+++ b/template/src/main/java/com/asyncapi/model/$$objectSchema$$.java
@@ -132,8 +132,8 @@ public class {{schemaName | camelCase | upperFirst}} {
      */{% endif %}
     @JsonProperty("{{propName}}")
     {%- if propName | isRequired(schema.required()) %}@NotNull{% endif %}
-    {%- if prop.minLength() or prop.maxLength() or prop.maxItems() or prop.minItems() %}@Size({% if prop.minLength() or prop.minItems() %}min = {{prop.minLength()}}{{prop.minItems()}}{% endif %}{% if prop.maxLength() or prop.maxItems() %}{% if prop.minLength() or prop.minItems() %},{% endif %}max = {{prop.maxLength()}}{{prop.maxItems()}}{% endif %}){% endif %}
-    {%- if prop.pattern() %}@Pattern(regexp="{{prop.pattern()}}"){% endif %}
+    {%- if prop.minLength() or prop.maxLength() or prop.maxItems() or prop.minItems() %}@Size({% if prop.minLength() or prop.minItems() %}min = {{prop.minLength()}}{{prop.minItems()}}{% endif %}{% if prop.maxLength() or prop.maxItems() %}{% if prop.minLength() or prop.minItems() %},{% endif %}max = {{prop.maxLength()}}{{prop.maxItems()}}{% endif %}){% endif %}    
+    {%- if prop.pattern() %}@Pattern(regexp="{{prop.pattern() | addBackSlashToPattern}}"){% endif %}
     {%- if prop.minimum() %}@Min({{prop.minimum()}}){% endif %}{% if prop.exclusiveMinimum() %}@Min({{prop.exclusiveMinimum() + 1}}){% endif %}
     {%- if prop.maximum() %}@Max({{prop.maximum()}}){% endif %}{% if prop.exclusiveMaximum() %}@Max({{prop.exclusiveMaximum() + 1}}){% endif %}
     public {{propType}} get{{className}}() {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

 when having a regex with \\ in pattern the openapi removes it from it.

For example having in the yaml:

```yaml
time:
      type: "string"
      pattern: "^\\d\\d:\\d\\d$"
```

will result in the java code to:

```java
@JsonProperty("time")@NotNull@Pattern(regexp="^\d\d:\d\d$")
public String getTime() {
    return time;
}
```

but should be:

```java
@JsonProperty("time")@NotNull@Pattern(regexp="^\\d\\d:\\d\\d$")
public String getTime() {
    return time;
}
```


**Related issue(s)**
Resolves #122