### PR TITLE
feat: set ADD_TYPE_INFO_HEADERS to true and control it with new addTypeInfoHeader param

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@ components:
 |javaPackage|The Java package of the generated classes. Alternatively you can set the specification extension `info.x-java-package`. If both extension and parameter are used, parameter has more priority.|No|`com.asyncapi`|
 |listenerPollTimeout|Only for Kafka. Timeout in ms to use when polling the consumer.|No|`3000`|
 |listenerConcurrency|Only for Kafka. Number of threads to run in the listener containers.|No|`3`|
+|addTypeInfoHeader|Only for Kafka. Add type information to message header.|No|`true`|
 |connectionTimeout|Only for MQTT. This value, measured in seconds, defines the maximum time interval the client will wait for the network connection to the MQTT server to be established. The default timeout is 30 seconds. A value of 0 disables timeout processing meaning the client will wait until the network connection is made successfully or fails.|No|`30`|
 |disconnectionTimeout|Only for MQTT. The completion timeout in milliseconds when disconnecting. The default disconnect completion timeout is 5000 milliseconds.|No|`5000`|
 |completionTimeout|Only for MQTT. The completion timeout in milliseconds for operations. The default completion timeout is 30000 milliseconds.|No|`30000`|

--- a/package.json
+++ b/package.json
@@ -120,6 +120,11 @@
         "description": "The Java package of the generated classes. Alternatively you can set the specification extension info.x-java-package",
         "default": "com.asyncapi",
         "required": false
+      },
+      "addTypeInfoHeader": {
+        "description": "Only for Kafka. Add type information to the message header",
+        "default": "true",
+        "required": false
       }
     },
     "generator": ">=0.50.0 <2.0.0",

--- a/partials/KafkaConfig.java
+++ b/partials/KafkaConfig.java
@@ -57,7 +57,9 @@ public class Config {
         props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, IntegerSerializer.class);
         props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
         props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
-        props.put(JsonSerializer.ADD_TYPE_INFO_HEADERS, true);
+    {% if params.addTypeInfoHeader === 'false' %}
+        props.put(JsonSerializer.ADD_TYPE_INFO_HEADERS, false);
+    {% endif -%}
         props.put(JsonSerializer.TYPE_MAPPINGS,
     {%- for schema in asyncapi.allSchemas().values() | isObjectType %}
         {%- if schema.uid() | first !== '<' and schema.type() === 'object' %}

--- a/partials/KafkaConfig.java
+++ b/partials/KafkaConfig.java
@@ -57,7 +57,7 @@ public class Config {
         props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, IntegerSerializer.class);
         props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
         props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
-        props.put(JsonSerializer.ADD_TYPE_INFO_HEADERS, false);
+        props.put(JsonSerializer.ADD_TYPE_INFO_HEADERS, true);
         props.put(JsonSerializer.TYPE_MAPPINGS,
     {%- for schema in asyncapi.allSchemas().values() | isObjectType %}
         {%- if schema.uid() | first !== '<' and schema.type() === 'object' %}


### PR DESCRIPTION
This sets the property of adding `ADD_TYPE_INFO_HEADERS` to true for Kafka. 

Currently, it is set to false, Causing the producer to not add headers, and then the corresponding consumer is not able to do the type conversion. 

the property being false, cause the next property i.e 
```
props.put(JsonSerializer.TYPE_MAPPINGS,
```
of no use, as it's not able to add the headers. 

**Related issue(s)**
This fixes the first part of the issue: https://github.com/asyncapi/java-spring-template/issues/137
Resolves #137
