### PR TITLE
feat: add support for security schemes in Kafka config

### DIFF
--- a/hooks/02_removeNotRelevantParts.js
+++ b/hooks/02_removeNotRelevantParts.js
@@ -8,7 +8,7 @@ module.exports = {
         for (let server of Object.values(asyncapi.servers())) {
             hasAmqp = hasAmqp || server.protocol() === 'amqp';
             hasMqtt = hasMqtt || server.protocol() === 'mqtt';
-            hasKafka = hasKafka || server.protocol() === 'kafka';
+            hasKafka = hasKafka || server.protocol() === 'kafka' || server.protocol() === 'kafka-secure';
         }
         if (!hasKafka) {
             // remove filers from template related only to Kafka

--- a/template/src/main/java/com/asyncapi/infrastructure/Config.java
+++ b/template/src/main/java/com/asyncapi/infrastructure/Config.java
@@ -10,6 +10,6 @@ package {{ params['userJavaPackage'] }}.infrastructure;
 {%- if asyncapi | isProtocol('mqtt') -%}
 {{- mqttConfig(asyncapi, params) -}}
 {%- endif -%}
-{%- if asyncapi | isProtocol('kafka') -%}
+{%- if (asyncapi | isProtocol('kafka')) or (asyncapi | isProtocol('kafka-secure')) -%}
 {{- kafkaConfig(asyncapi, params) -}}
 {%- endif -%}


### PR DESCRIPTION
This commit adds support for the new security schemes introduced
in AsyncAPI 2.1.0, for code generated for Kafka servers.

When provided with AsyncAPI specification documents that describe
Kafka clusters requiring authentication, the generator will now
be able to generate the correct configuration for client code.

I'm not familiar with Spring, so I'm absolutely open to suggestions
about whether the structure for these changes is appropriate. 

Signed-off-by: Dale Lane <dale.lane@uk.ibm.com>