### PR TITLE
feat: add help message about AnonymousSchema generated classes

### DIFF
--- a/hooks/98_userHelp.js
+++ b/hooks/98_userHelp.js
@@ -1,0 +1,55 @@
+const fs = require('fs');
+
+function checkForAnonymousSchemaObjects(generator) {
+    const modelPath = generator.targetDir + '/src/main/java/com/asyncapi/model';
+    var anonymousPresent = false;
+    fs.readdirSync(modelPath).forEach(file => {
+        if (file.startsWith('AnonymousSchema')) {
+            anonymousPresent = true;
+        }
+    });
+    if (anonymousPresent) {
+        console.log('The AnonymousSchemaN classes were generated in DTO classes.');
+        console.log('This may be a result of explicit schema object definition e.g.');
+        console.log('  schemas:\n' +
+            '    NamedObject:\n' +
+            '      type: object\n' +
+            '        properties:\n' +
+            '          field:\n' +
+            '            type: array\n' +
+            '            items:\n' +
+            '              type: object #Anonymous object\n' +
+            '              properties:\n' +
+            '                field:\n' +
+            '                  type: string');
+        console.log('OR');
+        console.log('  messages:\n' +
+            '    Message:\n' +
+            '      payload:\n' +
+            '        type: object #Anonymous object\n' +
+            '        properties:\n');
+        console.log('Please move such elements to child of "schemas:" to define proper names. ' +
+            'If changing of data model is not possible, you may use "$id" or "x-parser-schema-id" to set name e.g.');
+        console.log(
+            '        properties:\n' +
+            '          field:\n' +
+            '            type: array\n' +
+            '            items:\n' +
+            '              $id: ArrayElement #Name of object\n' +
+            '              type: object\n' +
+            '              properties:\n' +
+            '                field:\n' +
+            '                  type: string');
+    }
+}
+
+module.exports = {
+    /**
+     * Print help information for user if problems encountered during generation.
+     *
+     * @param generator
+     */
+    'generate:after': generator => {
+        checkForAnonymousSchemaObjects(generator);
+    }
+};

--- a/hooks/98_userHelp.js
+++ b/hooks/98_userHelp.js
@@ -3,14 +3,17 @@ const fs = require('fs');
 function checkForAnonymousSchemaObjects(generator) {
     const modelPath = generator.targetDir + '/src/main/java/com/asyncapi/model';
     var anonymousPresent = false;
+    var anonymousFileNames = [];
     fs.readdirSync(modelPath).forEach(file => {
         if (file.startsWith('AnonymousSchema')) {
             anonymousPresent = true;
+            anonymousFileNames.push(generator.templateParams['userJavaPackage'].replace(/\./g, '/') + '/model/' + file);
         }
     });
     if (anonymousPresent) {
-        console.log('The AnonymousSchemaN classes were generated in DTO classes.');
-        console.log('This may be a result of explicit schema object definition e.g.');
+        console.log('Following AnonymousSchemaN classes were generated in DTO classes:');
+        anonymousFileNames.forEach(name => console.log(name));
+        console.log('This may be a result of explicit (composition, inheritance, array items) Schema Object definition e.g.');
         console.log('  schemas:\n' +
             '    NamedObject:\n' +
             '      type: object\n' +
@@ -29,7 +32,7 @@ function checkForAnonymousSchemaObjects(generator) {
             '        type: object #Anonymous object\n' +
             '        properties:\n');
         console.log('Please move such elements to child of "schemas:" to define proper names. ' +
-            'If changing of data model is not possible, you may use "$id" or "x-parser-schema-id" to set name e.g.');
+            'If changing of data model is not possible, you may use "$id" to set name e.g.');
         console.log(
             '        properties:\n' +
             '          field:\n' +

--- a/hooks/98_userHelp.js
+++ b/hooks/98_userHelp.js
@@ -11,12 +11,11 @@ function checkForAnonymousSchemaObjects(generator) {
         }
     });
     if (anonymousPresent) {
-        console.log('Following AnonymousSchemaN classes were generated in DTO classes:');
-        anonymousFileNames.forEach(name => console.log(name));
-        console.log('This may be a result of explicit (composition, inheritance, array items) Schema Object definition e.g.');
-        const schemaWithAnonymous =
-`  schemas:
-    NamedObject:
+  console.log(`Following AnonymousSchema classes were generated in DTO classes:
+${anonymousFileNames.toString()}\n
+This may be a result of explicit (composition, inheritance, array items) Schema Object definition e.g.\n
+    schemas:
+      NamedObject:
       type: object
         properties:
           field:
@@ -25,29 +24,24 @@ function checkForAnonymousSchemaObjects(generator) {
               type: object #Anonymous object
               properties:
                 field:
-                  type: string`;
-        const messageWithAnonymous =
-`  messages:
-    Message:
-      payload:
-        type: object #Anonymous object
-        properties:`;
-        console.log(schemaWithAnonymous);
-        console.log('OR');
-        console.log(messageWithAnonymous);
-        console.log('Please move such elements to child of "schemas:" to define proper names. ' +
-            'If changing of data model is not possible, you may use "$id" to set name e.g.');
-        const objectWithId =
-`        properties:
-          field:
-            type: array
-            items:
-              $id: ArrayElement #Name of object
-              type: object
-              properties:
-                field:
-                  type: string`;
-        console.log(objectWithId);
+                  type: string
+\nOR\n
+    messages:
+      Message:
+        payload:
+          type: object #Anonymous object
+          properties:\n
+Please move such elements to child of "schemas:" to define proper names.
+If changing of data model is not possible, you may use "$id" to set name e.g.\n
+    properties:
+      field:
+        type: array
+        items:
+          $id: ArrayElement #Name of object
+          type: object
+          properties:
+            field:
+              type: string`);
     }
 }
 

--- a/hooks/98_userHelp.js
+++ b/hooks/98_userHelp.js
@@ -14,35 +14,40 @@ function checkForAnonymousSchemaObjects(generator) {
         console.log('Following AnonymousSchemaN classes were generated in DTO classes:');
         anonymousFileNames.forEach(name => console.log(name));
         console.log('This may be a result of explicit (composition, inheritance, array items) Schema Object definition e.g.');
-        console.log('  schemas:\n' +
-            '    NamedObject:\n' +
-            '      type: object\n' +
-            '        properties:\n' +
-            '          field:\n' +
-            '            type: array\n' +
-            '            items:\n' +
-            '              type: object #Anonymous object\n' +
-            '              properties:\n' +
-            '                field:\n' +
-            '                  type: string');
+        const schemaWithAnonymous =
+`  schemas:
+    NamedObject:
+      type: object
+        properties:
+          field:
+            type: array
+            items:
+              type: object #Anonymous object
+              properties:
+                field:
+                  type: string`;
+        const messageWithAnonymous =
+`  messages:
+    Message:
+      payload:
+        type: object #Anonymous object
+        properties:`;
+        console.log(schemaWithAnonymous);
         console.log('OR');
-        console.log('  messages:\n' +
-            '    Message:\n' +
-            '      payload:\n' +
-            '        type: object #Anonymous object\n' +
-            '        properties:\n');
+        console.log(messageWithAnonymous);
         console.log('Please move such elements to child of "schemas:" to define proper names. ' +
             'If changing of data model is not possible, you may use "$id" to set name e.g.');
-        console.log(
-            '        properties:\n' +
-            '          field:\n' +
-            '            type: array\n' +
-            '            items:\n' +
-            '              $id: ArrayElement #Name of object\n' +
-            '              type: object\n' +
-            '              properties:\n' +
-            '                field:\n' +
-            '                  type: string');
+        const objectWithId =
+`        properties:
+          field:
+            type: array
+            items:
+              $id: ArrayElement #Name of object
+              type: object
+              properties:
+                field:
+                  type: string`;
+        console.log(objectWithId);
     }
 }
 


### PR DESCRIPTION
**Description**

Many times users faced problem with `AnonymousSchema` model classes. This happens because some `schemas` element defined as sub-object (inside `allOf`, `items` e.t.c.)  and parser couldn't provide any significant name for them and so class name couldn't be defined.
This behavior is not directly problem of parser or template, but rather of user's AsyncAPI itself.
So, I decided to add info message with description how to discard  `AnonymousSchema` classes if generation result contains them.

**Related issue(s)**
See also #203 #131 #78