### PR TITLE
feat: added mqttClientId parameter with a defualt value

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,19 +45,19 @@ In order for the generator to know what names to use for some parameters it's ne
 
 #### Supported parameters
 
-|Name|Description|Required| Default                   |
-|---|---|---|---------------------------|
-|disableEqualsHashCode|Disable generation of equals and hashCode methods for model classes.|No| `false`                   |
-|inverseOperations|Generate an application that will publish messages to `publish` operation of channels and read messages from `subscribe` operation of channels. Literally this flag will simply swap `publish` and `subscribe` operations in the channels. <br> This flag will be useful when you want to generate a code of mock for your main application. Be aware, generation could be incomplete and manual changes will be required e.g. if bindings are defined only for case of main application.|No| `false`                   |
-|javaPackage|The Java package of the generated classes. Alternatively you can set the specification extension `info.x-java-package`. If both extension and parameter are used, parameter has more priority.|No| `com.asyncapi`            |
-|listenerPollTimeout|Only for Kafka. Timeout in ms to use when polling the consumer.|No| `3000`                    |
-|listenerConcurrency|Only for Kafka. Number of threads to run in the listener containers.|No| `3`                       |
-|addTypeInfoHeader|Only for Kafka. Add type information to message header.|No| `true`                    |
-|connectionTimeout|Only for MQTT. This value, measured in seconds, defines the maximum time interval the client will wait for the network connection to the MQTT server to be established. The default timeout is 30 seconds. A value of 0 disables timeout processing meaning the client will wait until the network connection is made successfully or fails.|No| `30`                      |
-|disconnectionTimeout|Only for MQTT. The completion timeout in milliseconds when disconnecting. The default disconnect completion timeout is 5000 milliseconds.|No| `5000`                    |
-|completionTimeout|Only for MQTT. The completion timeout in milliseconds for operations. The default completion timeout is 30000 milliseconds.|No| `30000`                   |
+|Name|Description|Required| Default              |
+|---|---|---|----------------------|
+|disableEqualsHashCode|Disable generation of equals and hashCode methods for model classes.|No| `false`              |
+|inverseOperations|Generate an application that will publish messages to `publish` operation of channels and read messages from `subscribe` operation of channels. Literally this flag will simply swap `publish` and `subscribe` operations in the channels. <br> This flag will be useful when you want to generate a code of mock for your main application. Be aware, generation could be incomplete and manual changes will be required e.g. if bindings are defined only for case of main application.|No| `false`              |
+|javaPackage|The Java package of the generated classes. Alternatively you can set the specification extension `info.x-java-package`. If both extension and parameter are used, parameter has more priority.|No| `com.asyncapi`       |
+|listenerPollTimeout|Only for Kafka. Timeout in ms to use when polling the consumer.|No| `3000`               |
+|listenerConcurrency|Only for Kafka. Number of threads to run in the listener containers.|No| `3`                  |
+|addTypeInfoHeader|Only for Kafka. Add type information to message header.|No| `true`               |
+|connectionTimeout|Only for MQTT. This value, measured in seconds, defines the maximum time interval the client will wait for the network connection to the MQTT server to be established. The default timeout is 30 seconds. A value of 0 disables timeout processing meaning the client will wait until the network connection is made successfully or fails.|No| `30`                 |
+|disconnectionTimeout|Only for MQTT. The completion timeout in milliseconds when disconnecting. The default disconnect completion timeout is 5000 milliseconds.|No| `5000`               |
+|completionTimeout|Only for MQTT. The completion timeout in milliseconds for operations. The default completion timeout is 30000 milliseconds.|No| `30000`              |
+|mqttClientId| Only for MQTT. Provides the client identifier for the MQTT server. This parameter overrides the value of the clientId if it's set in the AsyncAPI file.If both aren't provided, a default value is set.|No|                      |
 |asyncapiFileDir| Path where original AsyncAPI file will be stored.|No| `src/main/resources/api/` |
-|mqttClientId| Only for MQTT. Provides the client identifier for the MQTT server.|No| guest                     |
 #### Examples
 
 The shortest possible syntax:

--- a/README.md
+++ b/README.md
@@ -45,18 +45,19 @@ In order for the generator to know what names to use for some parameters it's ne
 
 #### Supported parameters
 
-|Name|Description|Required|Default|
-|---|---|---|---|
-|disableEqualsHashCode|Disable generation of equals and hashCode methods for model classes.|No|`false`|
-|inverseOperations|Generate an application that will publish messages to `publish` operation of channels and read messages from `subscribe` operation of channels. Literally this flag will simply swap `publish` and `subscribe` operations in the channels. <br> This flag will be useful when you want to generate a code of mock for your main application. Be aware, generation could be incomplete and manual changes will be required e.g. if bindings are defined only for case of main application.|No|`false`|
-|javaPackage|The Java package of the generated classes. Alternatively you can set the specification extension `info.x-java-package`. If both extension and parameter are used, parameter has more priority.|No|`com.asyncapi`|
-|listenerPollTimeout|Only for Kafka. Timeout in ms to use when polling the consumer.|No|`3000`|
-|listenerConcurrency|Only for Kafka. Number of threads to run in the listener containers.|No|`3`|
-|addTypeInfoHeader|Only for Kafka. Add type information to message header.|No|`true`|
-|connectionTimeout|Only for MQTT. This value, measured in seconds, defines the maximum time interval the client will wait for the network connection to the MQTT server to be established. The default timeout is 30 seconds. A value of 0 disables timeout processing meaning the client will wait until the network connection is made successfully or fails.|No|`30`|
-|disconnectionTimeout|Only for MQTT. The completion timeout in milliseconds when disconnecting. The default disconnect completion timeout is 5000 milliseconds.|No|`5000`|
-|completionTimeout|Only for MQTT. The completion timeout in milliseconds for operations. The default completion timeout is 30000 milliseconds.|No|`30000`|
-|asyncapiFileDir| Path where original AsyncAPI file will be stored.|No|`src/main/resources/api/`|
+|Name|Description|Required| Default                   |
+|---|---|---|---------------------------|
+|disableEqualsHashCode|Disable generation of equals and hashCode methods for model classes.|No| `false`                   |
+|inverseOperations|Generate an application that will publish messages to `publish` operation of channels and read messages from `subscribe` operation of channels. Literally this flag will simply swap `publish` and `subscribe` operations in the channels. <br> This flag will be useful when you want to generate a code of mock for your main application. Be aware, generation could be incomplete and manual changes will be required e.g. if bindings are defined only for case of main application.|No| `false`                   |
+|javaPackage|The Java package of the generated classes. Alternatively you can set the specification extension `info.x-java-package`. If both extension and parameter are used, parameter has more priority.|No| `com.asyncapi`            |
+|listenerPollTimeout|Only for Kafka. Timeout in ms to use when polling the consumer.|No| `3000`                    |
+|listenerConcurrency|Only for Kafka. Number of threads to run in the listener containers.|No| `3`                       |
+|addTypeInfoHeader|Only for Kafka. Add type information to message header.|No| `true`                    |
+|connectionTimeout|Only for MQTT. This value, measured in seconds, defines the maximum time interval the client will wait for the network connection to the MQTT server to be established. The default timeout is 30 seconds. A value of 0 disables timeout processing meaning the client will wait until the network connection is made successfully or fails.|No| `30`                      |
+|disconnectionTimeout|Only for MQTT. The completion timeout in milliseconds when disconnecting. The default disconnect completion timeout is 5000 milliseconds.|No| `5000`                    |
+|completionTimeout|Only for MQTT. The completion timeout in milliseconds for operations. The default completion timeout is 30000 milliseconds.|No| `30000`                   |
+|asyncapiFileDir| Path where original AsyncAPI file will be stored.|No| `src/main/resources/api/` |
+|mqttClientId| Only for MQTT. Provides the client identifier for the MQTT server.|No| guest                     |
 #### Examples
 
 The shortest possible syntax:

--- a/package.json
+++ b/package.json
@@ -115,6 +115,10 @@
         "default": 30000,
         "required": false
       },
+      "mqttClientId": {
+        "description": "Only for MQTT. Provides the client identifier for the MQTT server. This parameter overrides the value of the clientId if it's set in the AsyncAPI file.",
+        "required": false
+      },
       "asyncapiFileDir": {
         "description": "Parameter of @asyncapi/generator-hooks#createAsyncapiFile, allows to specify where original AsyncAPI file will be stored.",
         "default": "src/main/resources/api/",
@@ -128,11 +132,6 @@
       "addTypeInfoHeader": {
         "description": "Only for Kafka. Add type information to the message header",
         "default": "true",
-        "required": false
-      },
-      "mqttClientId": {
-        "description": "Only for MQTT. Provides the client identifier for the MQTT server.",
-        "default": "guest",
         "required": false
       }
     },

--- a/package.json
+++ b/package.json
@@ -129,6 +129,11 @@
         "description": "Only for Kafka. Add type information to the message header",
         "default": "true",
         "required": false
+      },
+      "mqttClientId": {
+        "description": "Only for MQTT. Provides the client identifier for the MQTT server.",
+        "default": "guest",
+        "required": false
       }
     },
     "generator": ">=1.8.27 <2.0.0",

--- a/template/src/main/resources/application.yml
+++ b/template/src/main/resources/application.yml
@@ -8,6 +8,7 @@
         {%- set hasSubscribe = true -%}
     {%- endif -%}
 {%- endfor -%}
+
 {%- for serverName, server in asyncapi.servers() %}{% if server.protocol() == 'amqp' %}
 amqp:
   broker: {% for line in server.description() | splitByLines %}
@@ -29,6 +30,7 @@ amqp:
     {% endif %}
   {% endfor %}
 {% endif %}
+
 {% if server.protocol() == 'mqtt' %}
 mqtt:
   broker: {% for line in server.description() | splitByLines %}
@@ -36,9 +38,13 @@ mqtt:
     address: {% if server.variable('port') %}{{server.url() | replace('{port}', server.variable('port').defaultValue())}}{% else %}{{server.url()}}{% endif %}
     username:
     password:
-    {% if server.binding('mqtt') and server.binding('mqtt').clientId %}clientId: {{server.binding('mqtt').clientId}}{% endif %}
-    {% if server.binding('mqtt') and server.binding('mqtt').cleanSession | isDefined %}cleanSession: {{server.binding('mqtt').cleanSession}}{% endif %}
-    {% if server.binding('mqtt') and server.binding('mqtt').lastWill %}lastWill:
+    {% if server.binding('mqtt') and server.binding('mqtt').clientId and (params.mqttClientId == 'guest') %}
+    clientId: {{ server.binding('mqtt').clientId }}
+    {% else %}
+    clientId: {{ params.mqttClientId }}
+    {% endif %}
+    {% if server.binding('mqtt') and server.binding('mqtt').cleanSession | isDefined %} cleanSession: {{server.binding('mqtt').cleanSession}}{% endif %}
+    {% if server.binding('mqtt') and server.binding('mqtt').lastWill %} lastWill:
       topic: {{server.binding('mqtt').lastWill.topic}}
       message: {{server.binding('mqtt').lastWill.message}}
       qos: {{server.binding('mqtt').lastWill.qos}}
@@ -56,6 +62,7 @@ mqtt:
     {{channel.subscribe().id() | camelCase}}: {{channelName}}
     {% endif %}{% endfor %}
 {% endif %}{% endfor %}
+
 {%- if asyncapi | isProtocol('kafka') %}
 spring:
   kafka: {% for serverName, server in asyncapi.servers() %}

--- a/template/src/main/resources/application.yml
+++ b/template/src/main/resources/application.yml
@@ -38,13 +38,15 @@ mqtt:
     address: {% if server.variable('port') %}{{server.url() | replace('{port}', server.variable('port').defaultValue())}}{% else %}{{server.url()}}{% endif %}
     username:
     password:
-    {% if server.binding('mqtt') and server.binding('mqtt').clientId and (params.mqttClientId == 'guest') %}
+    {% if params.mqttClientId %}
+    clientId : {{ params.mqttClientId }}
+    {% elif server.binding('mqtt') and server.binding('mqtt').clientId %}
     clientId: {{ server.binding('mqtt').clientId }}
     {% else %}
-    clientId: {{ params.mqttClientId }}
+    clientId: default
     {% endif %}
-    {% if server.binding('mqtt') and server.binding('mqtt').cleanSession | isDefined %} cleanSession: {{server.binding('mqtt').cleanSession}}{% endif %}
-    {% if server.binding('mqtt') and server.binding('mqtt').lastWill %} lastWill:
+    {% if server.binding('mqtt') and server.binding('mqtt').cleanSession | isDefined %}cleanSession: {{server.binding('mqtt').cleanSession}}{% endif %}
+    {% if server.binding('mqtt') and server.binding('mqtt').lastWill %}lastWill:
       topic: {{server.binding('mqtt').lastWill.topic}}
       message: {{server.binding('mqtt').lastWill.message}}
       qos: {{server.binding('mqtt').lastWill.qos}}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**
- A new parameter `mqttClientId` with a default value `guest` was added to `package.json`.
- The order in which the value is prioritized is - parameterValue > asyncApiValue > defaultValue

**Related issue(s)**
Resolves #293 