### PR TITLE
chore: update .asyncapi-tool

### DIFF
--- a/.asyncapi-tool
+++ b/.asyncapi-tool
@@ -1,7 +1,6 @@
 title: Java Spring Template
 filters:
   language: 
-  - Java
   - javascript
   technology:
   - Springboot


### PR DESCRIPTION
Removed Java as a language form asyncapi-tool file
Followup for https://github.com/asyncapi/java-spring-template/pull/339