### PR TITLE
fix: empty object generation

### DIFF
--- a/template/src/main/java/com/asyncapi/model/$$objectSchema$$.java
+++ b/template/src/main/java/com/asyncapi/model/$$objectSchema$$.java
@@ -158,6 +158,9 @@ public class {{schemaName | camelCase | upperFirst}} {
     {% endfor %}
     {% if params.disableEqualsHashCode === 'false' %}@Override
     public boolean equals(Object o) {
+    {%- if schema.properties() | length === 0 %}
+        return super.equals(o);
+    {% else %}
         if (this == o) {
             return true;
         }
@@ -167,11 +170,16 @@ public class {{schemaName | camelCase | upperFirst}} {
         {{schemaName | camelCase | upperFirst}} {{schemaName | camelCase}} = ({{schemaName | camelCase | upperFirst}}) o;
         return {% for propName, prop in schema.properties() %}{% set varName = propName | camelCase %}
             Objects.equals(this.{{varName}}, {{schemaName | camelCase}}.{{varName}}){% if not loop.last %} &&{% else %};{% endif %}{% endfor %}
+    {% endif -%}
     }
 
     @Override
     public int hashCode() {
+    {%- if schema.properties() | length === 0 %}
+        return super.hashCode();
+    {% else %}
         return Objects.hash({% for propName, prop in schema.properties() %}{{propName | camelCase}}{% if not loop.last %}, {% endif %}{% endfor %});
+    {% endif -%}
     }{% endif %}
 
     @Override

--- a/template/src/main/java/com/asyncapi/model/$$objectSchema$$.java
+++ b/template/src/main/java/com/asyncapi/model/$$objectSchema$$.java
@@ -156,9 +156,9 @@ public class {{schemaName | camelCase | upperFirst}} {
         this.{{varName}} = {{varName}};
     }
     {% endfor %}
-    {% if params.disableEqualsHashCode === 'false' %}@Override
+    {% if params.disableEqualsHashCode === 'false' %}@Override{% set hasProps = schema.properties() | length > 0 %}
     public boolean equals(Object o) {
-    {%- if schema.properties() | length === 0 %}
+    {%- if not hasProps %}
         return super.equals(o);
     {% else %}
         if (this == o) {
@@ -175,7 +175,7 @@ public class {{schemaName | camelCase | upperFirst}} {
 
     @Override
     public int hashCode() {
-    {%- if schema.properties() | length === 0 %}
+    {%- if not hasProps %}
         return super.hashCode();
     {% else %}
         return Objects.hash({% for propName, prop in schema.properties() %}{{propName | camelCase}}{% if not loop.last %}, {% endif %}{% endfor %});

--- a/tests/__snapshots__/map-format.test.js.snap
+++ b/tests/__snapshots__/map-format.test.js.snap
@@ -452,3 +452,56 @@ public class Interpret {
     }
 }"
 `;
+
+exports[`template integration tests for map format should generate correct DTO for empty object 1`] = `
+"package com.asyncapi.model;
+
+
+import jakarta.validation.constraints.*;
+import jakarta.validation.Valid;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import javax.annotation.processing.Generated;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Test correct generation of object without parameters
+ */
+@Generated(value="com.asyncapi.generator.template.spring", date="AnyDate")
+public class EmptyObject {
+    
+
+    
+    @Override
+    public boolean equals(Object o) {
+        return super.equals(o);
+    }
+
+    @Override
+    public int hashCode() {
+        return super.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return "class EmptyObject {\\n" +
+        
+                "}";
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+           return "null";
+        }
+        return o.toString().replace("\\n", "\\n    ");
+    }
+}"
+`;

--- a/tests/map-format.test.js
+++ b/tests/map-format.test.js
@@ -33,4 +33,22 @@ describe('template integration tests for map format', () => {
             expect(fileWithAnyDate).toMatchSnapshot();
         }
     });
+
+    it('should generate correct DTO for empty object', async() => {
+        const outputDir = generateFolderName();
+        const params = {};
+        const mapFormatExamplePath = './mocks/map-format.yml';
+
+        const generator = new Generator(path.normalize('./'), outputDir, { forceWrite: true, templateParams: params });
+        await generator.generateFromFile(path.resolve('tests', mapFormatExamplePath));
+
+        const expectedFiles = [
+            '/src/main/java/com/asyncapi/model/EmptyObject.java',
+        ];
+        for (const index in expectedFiles) {
+            const file = await readFile(path.join(outputDir, expectedFiles[index]), 'utf8');
+            const fileWithAnyDate = file.replace(/date="\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d\.\d+([+-][0-2]\d:[0-5]\d|Z)"/, 'date="AnyDate"');
+            expect(fileWithAnyDate).toMatchSnapshot();
+        }
+    });
 });

--- a/tests/mocks/map-format.yml
+++ b/tests/mocks/map-format.yml
@@ -76,6 +76,9 @@ components:
             additionalProperties:
               $ref: '#/components/schemas/Interpret'
   schemas:
+    emptyObject:
+      type: object
+      description: Test correct generation of object without parameters
     Album:
       description: Album
       type: object


### PR DESCRIPTION
**Description**

- If schema object has no properties it's hashCode and equals methods will rely on `super` 

**Related issue(s)**
Fixes #336