### PR TITLE
fix: use parameter generateTimestamp to suppress timestamp in @Genera…

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ It is RECOMMENDED to not use anonymous objects in payload and components definit
 |completionTimeout|Only for MQTT. The completion timeout in milliseconds for operations. The default completion timeout is 30000 milliseconds.| No       | `30000`                  |
 |mqttClientId| Only for MQTT. Provides the client identifier for the MQTT server. This parameter overrides the value of the clientId if it's set in the AsyncAPI file.If both aren't provided, a default value is set.| No       |                          |
 |asyncapiFileDir| Path where original AsyncAPI file will be stored.| No       | `src/main/resources/api/` |
+|generateTimestamp| Adds the generation timestamp to the @Generated annotation.| No       | `true`                   |
 ### Examples
 
 The shortest possible syntax:

--- a/package.json
+++ b/package.json
@@ -117,9 +117,14 @@
         "description": "Generate pom.xml Maven build file instead of Gradle build",
         "default": false,
         "required": false
+      },
+      "generateTimestamp": {
+        "description": "Adds the generation timestamp to the @Generated annotation",
+        "default": "true",
+        "required": false
       }
     },
-    "generator": ">=1.8.27 <2.0.0",
+    "generator": ">=1.8.27",
     "filters": [
       "@asyncapi/generator-filters"
     ],

--- a/template/src/main/java/com/asyncapi/model/$$message$$.java
+++ b/template/src/main/java/com/asyncapi/model/$$message$$.java
@@ -14,7 +14,7 @@ import java.util.Objects;
  * {{ line | safe}}{% endfor %}{% if message.examples() %}
  * Examples: {{message.examples() | examplesToString | safe}}{% endif %}
  */{% endif %}
-@Generated(value="com.asyncapi.generator.template.spring", date="{{''|currentTime }}")
+@Generated(value="com.asyncapi.generator.template.spring"{% if params.generateTimestamp === 'true' %}, date="{{''|currentTime }}"{%- endif %})
 public class {{messageName | camelCase | upperFirst}} {
     {%- if message.payload().anyOf() or message.payload().oneOf() %}
         {%- set payloadName = 'OneOf' %}{%- set hasPrimitive = false %}

--- a/template/src/main/java/com/asyncapi/model/$$objectSchema$$.java
+++ b/template/src/main/java/com/asyncapi/model/$$objectSchema$$.java
@@ -21,7 +21,7 @@ import java.util.Objects;
  * {{ line | safe}}{% endfor %}{% if schema.examples() %}
  * Examples: {{schema.examples() | examplesToString | safe}}{% endif %}
  */{% endif %}
-@Generated(value="com.asyncapi.generator.template.spring", date="{{''|currentTime }}")
+@Generated(value="com.asyncapi.generator.template.spring"{% if params.generateTimestamp === 'true' %}, date="{{''|currentTime }}"{%- endif %})
 public class {{schemaName | camelCase | upperFirst}} {
     {% for propName, prop in schema.properties() %}
         {%- set isRequired = propName | isRequired(schema.required()) %}

--- a/template/src/main/java/com/asyncapi/model/$$parameter$$.java
+++ b/template/src/main/java/com/asyncapi/model/$$parameter$$.java
@@ -20,7 +20,7 @@ import java.util.Objects;
 {% if parameter.hasDescription() %}/**{% for line in parameter.description() | splitByLines %}
  * {{ line | safe}}{% endfor %}
  */{% endif %}
-@Generated(value="com.asyncapi.generator.template.spring", date="{{''|currentTime }}")
+@Generated(value="com.asyncapi.generator.template.spring"{% if params.generateTimestamp === 'true' %}, date="{{''|currentTime }}"{%- endif %})
 public class {{parameterName | camelCase | upperFirst}} {
 {% set schema = parameter.schema() %}
 {% for propName, prop in schema.properties() %}

--- a/tests/parameters.test.js
+++ b/tests/parameters.test.js
@@ -86,4 +86,40 @@ describe('integration tests for generated files under different template paramet
             expect(existsSync(path.join(outputDir, notExpectedFiles[index]))).toBeFalsy();
         }
     });
+
+    it('should include timestamp in @Generated annotation when generateTimestamp is true', async () => {
+        const outputDir = generateFolderName();
+        const params = { generateTimestamp: 'true' };
+        const kafkaExamplePath = './mocks/kafka.yml';
+
+        const generator = new Generator(path.normalize('./'), outputDir, { forceWrite: true, templateParams: params });
+        await generator.generateFromFile(path.resolve('tests', kafkaExamplePath));
+
+        const filesToCheck = [
+            '/src/main/java/com/asyncapi/model/LightMeasured.java',
+            '/src/main/java/com/asyncapi/model/LightMeasuredPayload.java'
+        ];
+        for (const index in filesToCheck) {
+            const generatedFile = await readFile(path.join(outputDir, filesToCheck[index]), 'utf8');
+           expect(generatedFile).toMatch(/date=".*"/);
+        }
+    });
+
+    it('should not include timestamp in @Generated annotation when generateTimestamp is false', async () => {
+        const outputDir = generateFolderName();
+        const params = { generateTimestamp: 'false' };
+        const kafkaExamplePath = './mocks/kafka.yml';
+
+        const generator = new Generator(path.normalize('./'), outputDir, { forceWrite: true, templateParams: params });
+        await generator.generateFromFile(path.resolve('tests', kafkaExamplePath));
+
+        const filesToCheck = [
+            '/src/main/java/com/asyncapi/model/LightMeasured.java',
+            '/src/main/java/com/asyncapi/model/LightMeasuredPayload.java'
+        ];
+        for (const index in filesToCheck) {
+            const generatedFile = await readFile(path.join(outputDir, filesToCheck[index]), 'utf8');
+            expect(generatedFile).not.toMatch(/date=".*"/);
+        }
+    });
 });


### PR DESCRIPTION
**Description**

Use parameter `generateTimestamp` to suppress timestamp in `@Generated` annotation, see #433

**Related issue(s)**
Fixes https://github.com/asyncapi/java-spring-template/issues/433