### PR TITLE
fix: remove max generator version

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
         "required": false
       }
     },
-    "generator": ">=1.8.27 <2.0.0",
+    "generator": ">=1.8.27",
     "filters": [
       "@asyncapi/generator-filters"
     ],


### PR DESCRIPTION
**Description**

- Remove requirements for maximal version of generator.
https://github.com/asyncapi/java-spring-template/pull/422#issuecomment-2501421776
 
**Related issue(s)**
See also #422